### PR TITLE
Add per-application channel support

### DIFF
--- a/client/bundle_creator.cc
+++ b/client/bundle_creator.cc
@@ -115,6 +115,13 @@ HRESULT PopulateCommonData(const CommandLineExtraArgs& extra_args,
     }
   }
 
+  if (!extra_args.channel.IsEmpty()) {
+    hr = app->put_channel(CComBSTR(extra_args.channel));
+    if (FAILED(hr)) {
+      return hr;
+    }
+  }
+
   if (!extra_args.referral_id.IsEmpty()) {
     hr = app->put_referralId(CComBSTR(extra_args.referral_id));
     if (FAILED(hr)) {

--- a/client/bundle_creator_test.cc
+++ b/client/bundle_creator_test.cc
@@ -117,6 +117,10 @@ class BundleCreatorTest : public testing::Test {
     EXPECT_SUCCEEDED(app->get_clientId(&client_id));
     EXPECT_STREQ(extra_arg.client_id, client_id);
 
+    CComBSTR channel;
+    EXPECT_SUCCEEDED(app->get_channel(&channel));
+    EXPECT_STREQ(extra_arg.channel, channel);
+
     CComBSTR referral_id;
     EXPECT_SUCCEEDED(app->get_referralId(&referral_id));
     EXPECT_STREQ(extra_arg.referral_id, referral_id);

--- a/common/app_registry_utils.cc
+++ b/common/app_registry_utils.cc
@@ -366,6 +366,7 @@ void GetAppVersion(bool is_machine, const CString& app_id, CString* pv) {
 //    lang
 //    brand
 //    client
+//    channel
 //    iid
 //    experiment
 void GetClientStateData(bool is_machine,
@@ -375,6 +376,7 @@ void GetClientStateData(bool is_machine,
                         CString* lang,
                         CString* brand_code,
                         CString* client_id,
+                        CString* channel,
                         CString* iid,
                         CString* experiment_labels) {
   RegKey key;
@@ -399,6 +401,9 @@ void GetClientStateData(bool is_machine,
   }
   if (client_id) {
     key.GetValue(kRegValueClientId, client_id);
+  }
+  if (channel) {
+    key.GetValue(kRegValueChannel, channel);
   }
   if (iid) {
     key.GetValue(kRegValueInstallationId, iid);

--- a/common/app_registry_utils.h
+++ b/common/app_registry_utils.h
@@ -103,6 +103,7 @@ void GetClientStateData(bool is_machine,
                         CString* lang,
                         CString* brand_code,
                         CString* client_id,
+                        CString* channel,
                         CString* iid,
                         CString* experiment_labels);
 

--- a/common/app_registry_utils_unittest.cc
+++ b/common/app_registry_utils_unittest.cc
@@ -2259,6 +2259,7 @@ TEST_F(AppRegistryUtilsRegistryProtectedTest,
   const CString expected_lang         = _T("some lang");
   const CString expected_brand_code   = _T("some brand");
   const CString expected_client_id    = _T("some client id");
+  const CString expected_channel      = _T("some channel");
   const CString expected_iid          =
       _T("{7C0B6E56-B24B-436b-A960-A6EA201E886F}");
   const CString expected_experiment_label =
@@ -2280,6 +2281,9 @@ TEST_F(AppRegistryUtilsRegistryProtectedTest,
                                             kRegValueClientId,
                                             expected_client_id));
   EXPECT_HRESULT_SUCCEEDED(RegKey::SetValue(kOmahaUserClientStatePath,
+                                            kRegValueChannel,
+                                            expected_channel));
+  EXPECT_HRESULT_SUCCEEDED(RegKey::SetValue(kOmahaUserClientStatePath,
                                             kRegValueInstallationId,
                                             expected_iid));
   EXPECT_HRESULT_SUCCEEDED(RegKey::SetValue(kOmahaUserClientStatePath,
@@ -2287,7 +2291,7 @@ TEST_F(AppRegistryUtilsRegistryProtectedTest,
                                             expected_experiment_label));
 
   CString actual_pv, actual_ap, actual_lang, actual_brand_code,
-      actual_client_id, actual_experiment_label, actual_iid;
+      actual_client_id, actual_channel, actual_experiment_label, actual_iid;
 
   GetClientStateData(false,
                      kGoogleUpdateAppId,
@@ -2296,6 +2300,7 @@ TEST_F(AppRegistryUtilsRegistryProtectedTest,
                      &actual_lang,
                      &actual_brand_code,
                      &actual_client_id,
+                     &actual_channel,
                      &actual_iid,
                      &actual_experiment_label);
 
@@ -2304,6 +2309,7 @@ TEST_F(AppRegistryUtilsRegistryProtectedTest,
   EXPECT_STREQ(expected_lang, actual_lang);
   EXPECT_STREQ(expected_brand_code, actual_brand_code);
   EXPECT_STREQ(expected_client_id, actual_client_id);
+  EXPECT_STREQ(expected_channel, actual_channel);
   EXPECT_STREQ(expected_iid, actual_iid);
   EXPECT_STREQ(expected_experiment_label, actual_experiment_label);
 }
@@ -2315,6 +2321,7 @@ TEST_F(AppRegistryUtilsRegistryProtectedTest,
   const CString expected_lang         = _T("some lang");
   const CString expected_brand_code   = _T("some brand");
   const CString expected_client_id    = _T("some client id");
+  const CString expected_channel      = _T("some channel");
   const CString expected_iid          =
       _T("{7C0B6E56-B24B-436b-A960-A6EA201E886F}");
   const CString expected_experiment_label =
@@ -2336,6 +2343,9 @@ TEST_F(AppRegistryUtilsRegistryProtectedTest,
                                             kRegValueClientId,
                                             expected_client_id));
   EXPECT_HRESULT_SUCCEEDED(RegKey::SetValue(kOmahaMachineClientStatePath,
+                                            kRegValueChannel,
+                                            expected_channel));
+  EXPECT_HRESULT_SUCCEEDED(RegKey::SetValue(kOmahaMachineClientStatePath,
                                             kRegValueInstallationId,
                                             expected_iid));
   EXPECT_HRESULT_SUCCEEDED(RegKey::SetValue(kOmahaMachineClientStatePath,
@@ -2343,7 +2353,7 @@ TEST_F(AppRegistryUtilsRegistryProtectedTest,
                                             expected_experiment_label));
 
   CString actual_pv, actual_ap, actual_lang, actual_brand_code,
-      actual_client_id, actual_experiment_label, actual_iid;
+      actual_client_id, actual_channel, actual_experiment_label, actual_iid;
 
   GetClientStateData(true,
                      kGoogleUpdateAppId,
@@ -2352,6 +2362,7 @@ TEST_F(AppRegistryUtilsRegistryProtectedTest,
                      &actual_lang,
                      &actual_brand_code,
                      &actual_client_id,
+                     &actual_channel,
                      &actual_iid,
                      &actual_experiment_label);
 
@@ -2360,6 +2371,7 @@ TEST_F(AppRegistryUtilsRegistryProtectedTest,
   EXPECT_STREQ(expected_lang, actual_lang);
   EXPECT_STREQ(expected_brand_code, actual_brand_code);
   EXPECT_STREQ(expected_client_id, actual_client_id);
+  EXPECT_STREQ(expected_channel, actual_channel);
   EXPECT_STREQ(expected_iid, actual_iid);
   EXPECT_STREQ(expected_experiment_label, actual_experiment_label);
 }

--- a/common/command_line.h
+++ b/common/command_line.h
@@ -97,6 +97,7 @@ struct CommandLineExtraArgs {
   GUID installation_id;
   CString brand_code;
   CString client_id;
+  CString channel;
   CString experiment_labels;
   CString referral_id;
   CString language;

--- a/common/const_cmd_line.h
+++ b/common/const_cmd_line.h
@@ -250,6 +250,9 @@ const TCHAR* const kExtraArgBrandCode = _T("brand");
 // This value is used to set the initial client for Omaha and the client app.
 const TCHAR* const kExtraArgClientId = _T("client");
 
+// "channel" extra argument is the channel of the application (stable, dev, beta, etc.)
+const TCHAR* const kExtraArgChannel = _T("channel");
+
 // "experiments" extra argument is a set of experiment labels used to track
 // installs that are included in experiments.  Use "experiments" for
 // per-app arguments; use "omahaexperiments" for Omaha-specific labels.

--- a/common/const_goopdate.h
+++ b/common/const_goopdate.h
@@ -149,6 +149,7 @@ const TCHAR* const kRegValueAdditionalParams = _T("ap");
 const TCHAR* const kRegValueBrandCode        = _T("brand");
 const TCHAR* const kRegValueBrowser          = _T("browser");
 const TCHAR* const kRegValueClientId         = _T("client");
+const TCHAR* const kRegValueChannel          = _T("channel");
 const TCHAR* const kRegValueDidRun           = _T("dr");
 const TCHAR* const kRegValueExperimentLabels = _T("experiment_labels");
 const TCHAR* const kRegValueInstallationId   = _T("iid");

--- a/common/extra_args_parser.cc
+++ b/common/extra_args_parser.cc
@@ -267,6 +267,16 @@ HRESULT ExtraArgsParser::HandleToken(const CString& token,
     args->runtime_only = true;
 
   // The following args are per-app.
+  } else if (name.CompareNoCase(kExtraArgChannel) == 0) {
+    if (value.GetLength() > kMaxNameLength) {
+      return E_INVALIDARG;
+    }
+    HRESULT hr = ConvertUtf8UrlEncodedString(
+        value,
+        &args->channel);
+    if (FAILED(hr)) {
+      return hr;
+    }
   } else if (name.CompareNoCase(kExtraArgAdditionalParameters) == 0) {
     cur_extra_app_args_.ap = value;
   } else if (name.CompareNoCase(kExtraArgTTToken) == 0) {

--- a/common/ping.cc
+++ b/common/ping.cc
@@ -65,6 +65,7 @@ void Ping::LoadAppDataFromExtraArgs(const CommandLineExtraArgs& extra_args) {
     app_data.language = extra_args.language;
     app_data.brand_code = extra_args.brand_code;
     app_data.client_id = extra_args.client_id;
+    app_data.channel = extra_args.channel;
     app_data.installation_id = installation_id;
     app_data.experiment_labels = extra_args.apps[i].experiment_labels;
     apps_data_.push_back(app_data);
@@ -74,6 +75,7 @@ void Ping::LoadAppDataFromExtraArgs(const CommandLineExtraArgs& extra_args) {
   omaha_data_.language = extra_args.language;
   omaha_data_.brand_code = extra_args.brand_code;
   omaha_data_.client_id = extra_args.client_id;
+  omaha_data_.channel = extra_args.channel;
   omaha_data_.installation_id = installation_id;
   omaha_data_.experiment_labels = extra_args.experiment_labels;
 }
@@ -88,6 +90,7 @@ void Ping::LoadOmahaDataFromRegistry() {
       &omaha_data_.language,
       &omaha_data_.brand_code,
       &omaha_data_.client_id,
+      &omaha_data_.channel,
       &omaha_data_.installation_id,
       &omaha_data_.experiment_labels);
 }
@@ -104,6 +107,7 @@ void Ping::LoadAppDataFromRegistry(const std::vector<CString>& app_ids) {
         &app_data.language,
         &app_data.brand_code,
         &app_data.client_id,
+        &app_data.channel,
         &app_data.installation_id,
         &app_data.experiment_labels);
     apps_data_.push_back(app_data);
@@ -173,6 +177,7 @@ xml::request::App Ping::BuildOmahaApp(const CString& version,
   app.lang           = omaha_data_.language;
   app.brand_code     = omaha_data_.brand_code;
   app.client_id      = omaha_data_.client_id;
+  app.channel        = omaha_data_.channel;
   app.experiments    = omaha_data_.experiment_labels;
   app.iid            = omaha_data_.installation_id;
 
@@ -191,6 +196,7 @@ void Ping::BuildAppsPing(const PingEventPtr& ping_event) {
     app.lang           = apps_data_[i].language;
     app.brand_code     = apps_data_[i].brand_code;
     app.client_id      = apps_data_[i].client_id;
+    app.channel        = apps_data_[i].channel;
     app.experiments    = apps_data_[i].experiment_labels;
     app.iid            = apps_data_[i].installation_id;
 

--- a/common/ping.h
+++ b/common/ping.h
@@ -191,6 +191,7 @@ class Ping {
     CString language;
     CString brand_code;
     CString client_id;
+    CString channel;
     CString installation_id;
     CString pv;
     CString experiment_labels;

--- a/common/ping_test.cc
+++ b/common/ping_test.cc
@@ -45,6 +45,7 @@ TEST_F(PingTest, BuildOmahaPing) {
                    &command_line_extra_args.installation_id);
   command_line_extra_args.brand_code = _T("GGLS");
   command_line_extra_args.client_id  = _T("a client id");
+  command_line_extra_args.channel  = _T("a channel");
   command_line_extra_args.language   = _T("en");
 
   // Machine ping.
@@ -56,7 +57,14 @@ TEST_F(PingTest, BuildOmahaPing) {
                               ping_event2);
 
   CString expected_ping_request_substring;
-  expected_ping_request_substring.Format(_T("<app appid=\"{430FD4D0-B729-4F61-AA34-91526481799D}\" version=\"1.0.0.0\" nextversion=\"2.0.0.0\" lang=\"en\" brand=\"GGLS\" client=\"a client id\" iid=\"{DE06587E-E5AB-4364-A46B-F3AC733007B3}\"><event eventtype=\"2\" eventresult=\"1\" errorcode=\"10\" extracode1=\"20\"/><event eventtype=\"2\" eventresult=\"1\" errorcode=\"30\" extracode1=\"40\"/></app>"));  // NOLINT
+  expected_ping_request_substring.Format(_T("<app ")
+    _T("appid=\"{430FD4D0-B729-4F61-AA34-91526481799D}\" ")
+    _T("version=\"1.0.0.0\" nextversion=\"2.0.0.0\" lang=\"en\" ")
+    _T("brand=\"GGLS\" client=\"a client id\" tag=\"a channel\" ")
+    _T("iid=\"{DE06587E-E5AB-4364-A46B-F3AC733007B3}\">")
+    _T("<event eventtype=\"2\" eventresult=\"1\" errorcode=\"10\" extracode1=\"20\"/>")
+    _T("<event eventtype=\"2\" eventresult=\"1\" errorcode=\"30\" extracode1=\"40\"/>")
+    _T("</app>"));  // NOLINT
 
   CString actual_ping_request;
   install_ping.BuildRequestString(&actual_ping_request);
@@ -76,6 +84,7 @@ TEST_F(PingTest, BuildAppsPing) {
   const CString expected_lang         = _T("en");
   const CString expected_brand_code   = _T("GGLS");
   const CString expected_client_id    = _T("someclientid");
+  const CString expected_channel      = _T("somechannel");
   const CString expected_iid          =
       _T("{7C0B6E56-B24B-436b-A960-A6EA201E886F}");
   const CString expected_experiment_label =
@@ -93,6 +102,9 @@ TEST_F(PingTest, BuildAppsPing) {
   EXPECT_HRESULT_SUCCEEDED(RegKey::SetValue(kOmahaUserClientStatePath,
                                             kRegValueClientId,
                                             expected_client_id));
+  EXPECT_HRESULT_SUCCEEDED(RegKey::SetValue(kOmahaUserClientStatePath,
+                                            kRegValueChannel,
+                                            expected_channel));
   EXPECT_HRESULT_SUCCEEDED(RegKey::SetValue(kOmahaUserClientStatePath,
                                             kRegValueInstallationId,
                                             expected_iid));
@@ -113,7 +125,14 @@ TEST_F(PingTest, BuildAppsPing) {
   apps_ping.BuildAppsPing(ping_event);
 
   CString expected_ping_request_substring;
-  expected_ping_request_substring.Format(_T("<app appid=\"{430FD4D0-B729-4F61-AA34-91526481799D}\" version=\"1.3.23.0\" nextversion=\"\" lang=\"en\" brand=\"GGLS\" client=\"someclientid\" experiments=\"some_experiment=a|Fri, 14 Aug 2015 16:13:03 GMT\" iid=\"{7C0B6E56-B24B-436b-A960-A6EA201E886F}\"><event eventtype=\"2\" eventresult=\"1\" errorcode=\"34\" extracode1=\"6\"/></app>"));  // NOLINT
+  expected_ping_request_substring.Format(_T("<app ")
+    _T("appid=\"{430FD4D0-B729-4F61-AA34-91526481799D}\" ")
+    _T("version=\"1.3.23.0\" nextversion=\"\" lang=\"en\" ")
+    _T("brand=\"GGLS\" client=\"someclientid\" tag=\"somechannel\" ")
+    _T("experiments=\"some_experiment=a|Fri, 14 Aug 2015 16:13:03 GMT\" ")
+    _T("iid=\"{7C0B6E56-B24B-436b-A960-A6EA201E886F}\">")
+    _T("<event eventtype=\"2\" eventresult=\"1\" errorcode=\"34\" extracode1=\"6\"/>")
+    _T("</app>"));  // NOLINT
 
   CString actual_ping_request;
   apps_ping.BuildRequestString(&actual_ping_request);

--- a/common/protocol_definition.h
+++ b/common/protocol_definition.h
@@ -101,6 +101,8 @@ struct App {
 
     CString client_id;
 
+    CString channel;
+
     CString experiments;
 
     int install_time_diff_sec;

--- a/common/xml_const.cc
+++ b/common/xml_const.cc
@@ -100,6 +100,7 @@ const TCHAR* const kSize = _T("size");
 const TCHAR* const kStatus = _T("status");
 const TCHAR* const kSuccessAction = _T("onsuccess");
 const TCHAR* const kSuccessUrl = _T("successurl");
+const TCHAR* const kTag = _T("tag");
 const TCHAR* const kTestSource = _T("testsource");
 const TCHAR* const kTerminateAllBrowsers = _T("terminateallbrowsers");
 const TCHAR* const kTTToken = _T("tttoken");

--- a/common/xml_const.h
+++ b/common/xml_const.h
@@ -105,6 +105,7 @@ extern const TCHAR* const kSize;
 extern const TCHAR* const kStatus;
 extern const TCHAR* const kSuccessAction;
 extern const TCHAR* const kSuccessUrl;
+extern const TCHAR* const kTag;
 extern const TCHAR* const kTestSource;
 extern const TCHAR* const kTerminateAllBrowsers;
 extern const TCHAR* const kTTToken;

--- a/common/xml_parser.cc
+++ b/common/xml_parser.cc
@@ -1057,6 +1057,14 @@ HRESULT XmlParser::BuildAppElement(IXMLDOMNode* parent_node) {
       return hr;
     }
 
+    hr = AddXMLAttributeNode(element,
+                             kXmlNamespace,
+                             xml::attribute::kTag,
+                             app.channel);
+    if (FAILED(hr)) {
+      return hr;
+    }
+
     // TODO(omaha3): Determine whether or not the server is able to accept an
     // empty string here.  If so, remove this IsEmpty() check, and always emit.
     if (!app.experiments.IsEmpty()) {

--- a/common/xml_parser_unittest.cc
+++ b/common/xml_parser_unittest.cc
@@ -102,7 +102,19 @@ TEST_F(XmlParserTest, GenerateRequestWithoutUserId_MachineUpdateRequest) {
   app2.experiments = _T("url_exp_2=a|Fri, 14 Aug 2015 16:13:03 GMT");
   xml_request.apps.push_back(app2);
 
-  CString expected_buffer = _T("<?xml version=\"1.0\" encoding=\"UTF-8\"?><request protocol=\"3.0\" version=\"1.2.3.4\" ismachine=\"1\" sessionid=\"unittest_session\" installsource=\"unittest_install\" originurl=\"http://go/foo/&quot;\" testsource=\"dev\" requestid=\"{387E2718-B39C-4458-98CC-24B5293C8383}\" periodoverridesec=\"100000\"><os platform=\"win\" version=\"6.0\" sp=\"Service Pack 1\" arch=\"x86\"/><app appid=\"{8A69D345-D564-463C-AFF1-A69D9E530F96}\" version=\"\" nextversion=\"\" ap=\"ap_with_update_check\" lang=\"en\" brand=\"\" client=\"\"><updatecheck/><data name=\"install\" index=\"verboselogging\"/><ping active=\"0\" r=\"5\"/></app><app appid=\"{AD3D0CC0-AD1E-4b1f-B98E-BAA41DCE396C}\" version=\"1.0\" nextversion=\"2.0\" ap=\"ap_with_no_update_check\" lang=\"en\" brand=\"\" client=\"\" experiments=\"url_exp_2=a|Fri, 14 Aug 2015 16:13:03 GMT\"/></request>");  // NOLINT
+  CString expected_buffer = _T("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+    _T("<request protocol=\"3.0\" version=\"1.2.3.4\" ismachine=\"1\" sessionid=\"unittest_session\" ")
+    _T("installsource=\"unittest_install\" originurl=\"http://go/foo/&quot;\" testsource=\"dev\" ")
+    _T("requestid=\"{387E2718-B39C-4458-98CC-24B5293C8383}\" periodoverridesec=\"100000\">")
+    _T("<os platform=\"win\" version=\"6.0\" sp=\"Service Pack 1\" arch=\"x86\"/>")
+    _T("<app appid=\"{8A69D345-D564-463C-AFF1-A69D9E530F96}\" version=\"\" nextversion=\"\" ")
+    _T("ap=\"ap_with_update_check\" lang=\"en\" brand=\"\" client=\"\" tag=\"\">")
+    _T("<updatecheck/>")
+    _T("<data name=\"install\" index=\"verboselogging\"/>")
+    _T("<ping active=\"0\" r=\"5\"/></app>")
+    _T("<app appid=\"{AD3D0CC0-AD1E-4b1f-B98E-BAA41DCE396C}\" version=\"1.0\" nextversion=\"2.0\" ")
+    _T("ap=\"ap_with_no_update_check\" lang=\"en\" brand=\"\" client=\"\" tag=\"\" ")
+    _T("experiments=\"url_exp_2=a|Fri, 14 Aug 2015 16:13:03 GMT\"/></request>");  // NOLINT
 
   CString actual_buffer;
   EXPECT_HRESULT_SUCCEEDED(XmlParser::SerializeRequest(*update_request,
@@ -155,7 +167,20 @@ TEST_F(XmlParserTest, GenerateRequestWithUserId_MachineUpdateRequest) {
   app2.experiments = _T("url_exp_2=a|Fri, 14 Aug 2015 16:13:03 GMT");
   xml_request.apps.push_back(app2);
 
-  CString expected_buffer = _T("<?xml version=\"1.0\" encoding=\"UTF-8\"?><request protocol=\"3.0\" version=\"4.3.2.1\" ismachine=\"1\" sessionid=\"unittest_session\" userid=\"{c5bcb37e-47eb-4331-a544-2f31101951ab}\" installsource=\"unittest_install\" originurl=\"http://go/bar/&quot;\" testsource=\"dev\" requestid=\"{387E2718-B39C-4458-98CC-24B5293C8384}\" periodoverridesec=\"200000\"><os platform=\"win\" version=\"7.0\" sp=\"Service Pack 2\" arch=\"x64\"/><app appid=\"{8A69D345-D564-463C-AFF1-A69D9E530F97}\" version=\"\" nextversion=\"\" ap=\"ap_with_update_check\" lang=\"en\" brand=\"\" client=\"\"><updatecheck/><data name=\"install\" index=\"verboselogging\"/><ping active=\"0\" r=\"5\"/></app><app appid=\"{AD3D0CC0-AD1E-4b1f-B98E-BAA41DCE396D}\" version=\"1.0\" nextversion=\"2.0\" ap=\"ap_with_no_update_check\" lang=\"en\" brand=\"\" client=\"\" experiments=\"url_exp_2=a|Fri, 14 Aug 2015 16:13:03 GMT\"/></request>");  // NOLINT
+  CString expected_buffer = _T("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+    _T("<request protocol=\"3.0\" version=\"4.3.2.1\" ismachine=\"1\" sessionid=\"unittest_session\" ")
+    _T("userid=\"{c5bcb37e-47eb-4331-a544-2f31101951ab}\" installsource=\"unittest_install\" ")
+    _T("originurl=\"http://go/bar/&quot;\" testsource=\"dev\" ")
+    _T("requestid=\"{387E2718-B39C-4458-98CC-24B5293C8384}\" periodoverridesec=\"200000\">")
+    _T("<os platform=\"win\" version=\"7.0\" sp=\"Service Pack 2\" arch=\"x64\"/>")
+    _T("<app appid=\"{8A69D345-D564-463C-AFF1-A69D9E530F97}\" version=\"\" nextversion=\"\" ")
+    _T("ap=\"ap_with_update_check\" lang=\"en\" brand=\"\" client=\"\" tag=\"\">")
+    _T("<updatecheck/>")
+    _T("<data name=\"install\" index=\"verboselogging\"/>")
+    _T("<ping active=\"0\" r=\"5\"/></app>")
+    _T("<app appid=\"{AD3D0CC0-AD1E-4b1f-B98E-BAA41DCE396D}\" version=\"1.0\" nextversion=\"2.0\" ")
+    _T("ap=\"ap_with_no_update_check\" lang=\"en\" brand=\"\" client=\"\" tag=\"\" ")
+    _T("experiments=\"url_exp_2=a|Fri, 14 Aug 2015 16:13:03 GMT\"/></request>");  // NOLINT
 
   CString actual_buffer;
   EXPECT_HRESULT_SUCCEEDED(XmlParser::SerializeRequest(*update_request,

--- a/goopdate/app.cc
+++ b/goopdate/app.cc
@@ -174,6 +174,19 @@ STDMETHODIMP App::put_clientId(BSTR client_id) {
   return S_OK;
 }
 
+STDMETHODIMP App::get_channel(BSTR* channel) {
+  __mutexScope(model()->lock());
+  ASSERT1(channel);
+  *channel = channel_.AllocSysString();
+  return S_OK;
+}
+
+STDMETHODIMP App::put_channel(BSTR channel) {
+  __mutexScope(model()->lock());
+  channel_ = channel;
+  return S_OK;
+}
+
 STDMETHODIMP App::get_labels(BSTR* labels) {
   __mutexScope(model()->lock());
   ASSERT1(labels);
@@ -550,6 +563,11 @@ GUID App::iid() const {
 CString App::client_id() const {
   __mutexScope(model()->lock());
   return client_id_;
+}
+
+CString App::channel() const {
+  __mutexScope(model()->lock());
+  return channel_;
 }
 
 CString App::GetExperimentLabels() const {
@@ -1071,6 +1089,16 @@ STDMETHODIMP AppWrapper::get_clientId(BSTR* client_id) {
 STDMETHODIMP AppWrapper::put_clientId(BSTR client_id) {
   __mutexScope(model()->lock());
   return wrapped_obj()->put_clientId(client_id);
+}
+
+STDMETHODIMP AppWrapper::get_channel(BSTR* channel) {
+  __mutexScope(model()->lock());
+  return wrapped_obj()->get_channel(channel);
+}
+
+STDMETHODIMP AppWrapper::put_channel(BSTR channel) {
+  __mutexScope(model()->lock());
+  return wrapped_obj()->put_channel(channel);
 }
 
 STDMETHODIMP AppWrapper::get_labels(BSTR* labels) {

--- a/goopdate/app.h
+++ b/goopdate/app.h
@@ -106,6 +106,8 @@ class App : public ModelObject {
 
   CString client_id() const;
 
+  CString channel() const;
+
   CString GetExperimentLabels() const;
 
   CString referral_id() const;
@@ -173,6 +175,9 @@ class App : public ModelObject {
 
   STDMETHOD(get_clientId)(BSTR* client_id);
   STDMETHOD(put_clientId)(BSTR client_id);
+
+  STDMETHOD(get_channel)(BSTR* channel);
+  STDMETHOD(put_channel)(BSTR channel);
 
   STDMETHOD(get_labels)(BSTR* labels);
   STDMETHOD(put_labels)(BSTR labels);
@@ -356,6 +361,7 @@ class App : public ModelObject {
   GUID iid_;
   CString brand_code_;
   CString client_id_;
+  CString channel_;
   // TODO(omaha3): Rename member and registry value to match the COM property.
   CString referral_id_;
   uint32 install_time_diff_sec_;
@@ -436,6 +442,9 @@ class ATL_NO_VTABLE AppWrapper
 
   STDMETHOD(get_clientId)(BSTR* client_id);
   STDMETHOD(put_clientId)(BSTR client_id);
+
+  STDMETHOD(get_channel)(BSTR* channel);
+  STDMETHOD(put_channel)(BSTR channel);
 
   STDMETHOD(get_labels)(BSTR* labels);
   STDMETHOD(put_labels)(BSTR labels);

--- a/goopdate/app_manager.cc
+++ b/goopdate/app_manager.cc
@@ -468,6 +468,7 @@ HRESULT AppManager::CreateClientStateKey(const GUID& app_guid,
 //    iid
 //    brand
 //    client
+//    channel
 //    experiment
 //    (referral is intentionally not read)
 //    InstallTime (converted to diff)
@@ -589,6 +590,7 @@ HRESULT AppManager::ReadAppPersistentData(App* app) {
   client_state_key.GetValue(kRegValueBrandCode, &app->brand_code_);
   ASSERT1(app->brand_code_.GetLength() <= kBrandIdLength);
   client_state_key.GetValue(kRegValueClientId, &app->client_id_);
+  client_state_key.GetValue(kRegValueChannel, &app->channel_);
 
   // We do not need the referral_id.
 
@@ -663,6 +665,7 @@ HRESULT AppManager::ReadUninstalledAppPersistentData(App* app) {
 //    ap
 //    brand (in SetAppBranding)
 //    client (in SetAppBranding)
+//    channel
 //    experiment
 //    referral (in SetAppBranding)
 //    InstallTime (in SetAppBranding; converted from diff)
@@ -713,6 +716,13 @@ HRESULT AppManager::WritePreInstallData(const App& app) {
   } else {
     VERIFY1(SUCCEEDED(client_state_key.SetValue(kRegValueAdditionalParams,
                                                 app.ap())));
+  }
+
+  if (app.channel().IsEmpty()) {
+    VERIFY1(SUCCEEDED(client_state_key.DeleteValue(kRegValueChannel)));
+  } else {
+    VERIFY1(SUCCEEDED(client_state_key.SetValue(kRegValueChannel,
+                                                app.channel())));
   }
 
   CString state_key_path = GetClientStateKeyName(app.app_guid());

--- a/goopdate/app_manager_unittest.cc
+++ b/goopdate/app_manager_unittest.cc
@@ -186,6 +186,11 @@ class AppManagerTestBase : public AppTestBaseWithRegistryOverride {
                                                  app.client_id_));
     }
 
+    if (!app.channel_.IsEmpty()) {
+      ASSERT_SUCCEEDED(client_state_key.SetValue(kRegValueChannel,
+                                                 app.channel_));
+    }
+
     if (!app.referral_id_.IsEmpty()) {
       ASSERT_SUCCEEDED(client_state_key.SetValue(kRegValueReferralId,
                                                  app.referral_id_));

--- a/goopdate/download_complete_ping_event_test.cc
+++ b/goopdate/download_complete_ping_event_test.cc
@@ -26,6 +26,7 @@ namespace {
   const CString kLang = _T("en");
   const CString kBrandCode = _T("GOOG");
   const CString kClientId = _T("testclientid");
+  const CString kChannel = _T("testchannel");
   const CString kIid = _T("{7C0B6E56-B24B-436b-A960-A6EA201E886D}");
 }  // namespace
 
@@ -52,6 +53,9 @@ class DownloadCompletePingEventTest : public testing::Test {
     EXPECT_HRESULT_SUCCEEDED(RegKey::SetValue(kOmahaUserClientStatePath,
                                               kRegValueClientId,
                                               kClientId));
+    EXPECT_HRESULT_SUCCEEDED(RegKey::SetValue(kOmahaUserClientStatePath,
+                                              kRegValueChannel,
+                                              kChannel));
     EXPECT_HRESULT_SUCCEEDED(RegKey::SetValue(kOmahaUserClientStatePath,
                                               kRegValueInstallationId,
                                               kIid));
@@ -90,12 +94,12 @@ TEST_F(DownloadCompletePingEventTest, BuildDownloadCompletePing) {
   CString expected_ping_request_substring;
   expected_ping_request_substring.Format(
       _T("<app appid=\"%s\" version=\"%s\" nextversion=\"\" lang=\"%s\" ")
-      _T("brand=\"%s\" client=\"%s\" iid=\"%s\">")
+      _T("brand=\"%s\" client=\"%s\" tag=\"%s\" iid=\"%s\">")
       _T("<event eventtype=\"%d\" eventresult=\"%d\" ")
       _T("errorcode=\"%d\" extracode1=\"%d\" ")
       _T("download_time_ms=\"%d\" downloaded=\"%I64u\" total=\"%I64u\"/>")
       _T("</app>"),
-      GOOPDATE_APP_ID, kPv, kLang, kBrandCode, kClientId, kIid,
+      GOOPDATE_APP_ID, kPv, kLang, kBrandCode, kClientId, kChannel, kIid,
       PingEvent::EVENT_INSTALL_COMPLETE, PingEvent::EVENT_RESULT_SUCCESS,
       error_code, extra_code1, download_time_ms, num_bytes_downloaded,
       app_packages_total_size);
@@ -132,11 +136,11 @@ TEST_F(DownloadCompletePingEventTest, BuildDownloadCompletePing_NoDownload) {
   CString expected_ping_request_substring;
   expected_ping_request_substring.Format(
       _T("<app appid=\"%s\" version=\"%s\" nextversion=\"\" lang=\"%s\" ")
-      _T("brand=\"%s\" client=\"%s\" iid=\"%s\">")
+      _T("brand=\"%s\" client=\"%s\" tag=\"%s\" iid=\"%s\">")
       _T("<event eventtype=\"%d\" eventresult=\"%d\" ")
       _T("errorcode=\"%d\" extracode1=\"%d\"/>")
       _T("</app>"),
-      GOOPDATE_APP_ID, kPv, kLang, kBrandCode, kClientId, kIid,
+      GOOPDATE_APP_ID, kPv, kLang, kBrandCode, kClientId, kChannel, kIid,
       PingEvent::EVENT_INSTALL_COMPLETE, PingEvent::EVENT_RESULT_SUCCESS,
       error_code, extra_code1);
 

--- a/goopdate/omaha3_idl.idl
+++ b/goopdate/omaha3_idl.idl
@@ -259,6 +259,9 @@ interface IApp : IDispatch {
   [propget] HRESULT clientId([out, retval] BSTR*);
   [propput] HRESULT clientId([in] BSTR);
 
+  [propget] HRESULT channel([out, retval] BSTR*);
+  [propput] HRESULT channel([in] BSTR);
+
   [propget] HRESULT labels([out, retval] BSTR*);
   [propput] HRESULT labels([in] BSTR);
 

--- a/goopdate/update_request_utils.cc
+++ b/goopdate/update_request_utils.cc
@@ -48,6 +48,7 @@ void BuildRequest(const App* app,
   request_app.iid           = GuidToString(app->iid());
   request_app.brand_code    = app->brand_code();
   request_app.client_id     = app->client_id();
+  request_app.channel       = app->channel();
   request_app.experiments   = app->GetExperimentLabels();
   request_app.ap            = app->ap();
 

--- a/official/common/const_goopdate.h
+++ b/official/common/const_goopdate.h
@@ -149,6 +149,7 @@ const TCHAR* const kRegValueAdditionalParams = _T("ap");
 const TCHAR* const kRegValueBrandCode        = _T("brand");
 const TCHAR* const kRegValueBrowser          = _T("browser");
 const TCHAR* const kRegValueClientId         = _T("client");
+const TCHAR* const kRegValueChannel          = _T("channel");
 const TCHAR* const kRegValueDidRun           = _T("dr");
 const TCHAR* const kRegValueExperimentLabels = _T("experiment_labels");
 const TCHAR* const kRegValueInstallationId   = _T("iid");

--- a/official/goopdate/omaha3_idl.idl
+++ b/official/goopdate/omaha3_idl.idl
@@ -259,6 +259,9 @@ interface IApp : IDispatch {
   [propget] HRESULT clientId([out, retval] BSTR*);
   [propput] HRESULT clientId([in] BSTR);
 
+  [propget] HRESULT channel([out, retval] BSTR*);
+  [propput] HRESULT channel([in] BSTR);
+
   [propget] HRESULT labels([out, retval] BSTR*);
   [propput] HRESULT labels([in] BSTR);
 


### PR DESCRIPTION
- Added `channel` extra argument for metainstaller tag
- Passing channel to the server using `app.tag` attribute
