### PR TITLE
change update checking from 5 hours to 30 mins 

### DIFF
--- a/base/constants.h
+++ b/base/constants.h
@@ -406,7 +406,7 @@ const int kMinLastCheckPeriodSec = 60;  // 60 seconds minimum.
 // Internal users are supposed to update at least once every hour. Therefore,
 // start workers every 30 minutes.
 //const int kAUCheckPeriodMs             = 60 * 60 * 1000;  // Hourly.
-    const int kAUCheckPeriodMs             = 30 * 60 * 1000;
+const int kAUCheckPeriodMs             = 30 * 60 * 1000;
 const int kAUCheckPeriodInternalUserMs = 30 * 60 * 1000;  // 30 minutes.
 
 // Avoids starting workers too soon. This helps reduce disk thrashing at


### PR DESCRIPTION
Our automation team wants to change the update checking interval from 5 hours to 30 mins. Please check if it is the right place to change.
