### PR TITLE
Fix signing of output files

### DIFF
--- a/omaha/clickonce/build.scons
+++ b/omaha/clickonce/build.scons
@@ -49,7 +49,7 @@ exe_output_unsigned = env.Command(
 # Inform Hammer that the .res file must be built before the executeable
 env.Requires(exe_output_unsigned, clickonce_res)
 
-exe_output = env.DualSignedBinary(
+exe_output = env.SignedBinary(
     target=clickonce_binary,
     source=exe_output_unsigned,
 )

--- a/omaha/crashhandler/build.scons
+++ b/omaha/crashhandler/build.scons
@@ -125,7 +125,7 @@ def BuildCrashHandler(local_env):
       source=gch_inputs,
   )
 
-  signed_crash_handler = gch_env.DualSignedBinary(
+  signed_crash_handler = gch_env.SignedBinary(
       target='%s.exe' % exe_name,
       source=unsigned_crash_handler,
   )

--- a/omaha/enterprise/installer/custom_actions/build.scons
+++ b/omaha/enterprise/installer/custom_actions/build.scons
@@ -74,7 +74,7 @@ def BuildShowErrorActionDll(omaha_version_info):
       source=dll_inputs,
   )
 
-  signed_dll = dll_env.DualSignedBinary(
+  signed_dll = dll_env.SignedBinary(
       target='%s%s.dll' % (prefix, signed_target_name),
       source=unsigned_dll,
   )

--- a/omaha/google_update/build.scons
+++ b/omaha/google_update/build.scons
@@ -96,7 +96,7 @@ unsigned_exe_output = exe_env.ComponentProgram(
     source=exe_inputs,
 )
 
-sign_output = env.DualSignedBinary(
+sign_output = env.SignedBinary(
     target='ViaSatUpdate_signed.exe',
     source=unsigned_exe_output,
 )

--- a/omaha/goopdate/build.scons
+++ b/omaha/goopdate/build.scons
@@ -66,7 +66,7 @@ def BuildCOMForwarder(cmd_line_switch,
       prog_name='%s_unsigned' % signed_exe_name,
       source=com_forwarder_inputs,
   )
-  signed_broker = com_forwarder_env.DualSignedBinary(
+  signed_broker = com_forwarder_env.SignedBinary(
       target='%s.exe' % signed_exe_name,
       source=unsigned_broker,
   )
@@ -118,7 +118,7 @@ def BuildCOMRegisterShell64():
           'com_register_shell.cc',
           ]
   )
-  signed_exe = com_register_shell_env.DualSignedBinary(
+  signed_exe = com_register_shell_env.SignedBinary(
       target='ViaSatUpdateComRegisterShell64.exe',
       source=unsigned_exe,
   )
@@ -264,7 +264,7 @@ def BuildGoogleUpdateHandlerDll(handler_env,
       source=inputs,
   )
 
-  signed_dll = handler_env.DualSignedBinary(
+  signed_dll = handler_env.SignedBinary(
       target='%s%s%s.dll' % (prefix, psname, suffix),
       source=unsigned_dll,
   )
@@ -496,7 +496,7 @@ for omaha_version_info in env['omaha_versions_info']:
       source=inputs,
   )
 
-  signed_dll = temp_env.DualSignedBinary(
+  signed_dll = temp_env.SignedBinary(
       target=prefix + 'vsupdate.dll',
       source=unsigned_dll,
   )
@@ -567,7 +567,7 @@ unsigned_test_installer = test_installer_env.ComponentProgram(
     prog_name='TestOmahaExeInstaller_unsigned',
     source=test_installer_inputs,
 )
-signed_test_installer = test_installer_env.DualSignedBinary(
+signed_test_installer = test_installer_env.SignedBinary(
     target='TestOmahaExeInstaller.exe',
     source=unsigned_test_installer,
 )

--- a/omaha/goopdate/resources/build.scons
+++ b/omaha/goopdate/resources/build.scons
@@ -85,7 +85,7 @@ for omaha_version_info in local_env['omaha_versions_info']:
         source=lang_inputs
     )
 
-    signed_dll = lang_env.DualSignedBinary(
+    signed_dll = lang_env.SignedBinary(
         target='%s/%svsupdateres_%s.dll' % (lang, prefix, lang),
         source=unsigned_dll,
     )

--- a/omaha/installers/build_metainstaller.py
+++ b/omaha/installers/build_metainstaller.py
@@ -170,7 +170,7 @@ def BuildMetaInstaller(
   )
 
   authenticode_signed_target_prefix = 'authenticode_'
-  authenticode_signed_exe = env.DualSignedBinary(
+  authenticode_signed_exe = env.SignedBinary(
       target=authenticode_signed_target_prefix + target_name,
       source=merged_output,
       )

--- a/omaha/plugins/update/build.scons
+++ b/omaha/plugins/update/build.scons
@@ -198,7 +198,7 @@ def BuildNpGoogleUpdateDll(omaha_version_info):
       use_pch_default=False,
   )
 
-  signed_dll = plugin_env.DualSignedBinary(
+  signed_dll = plugin_env.SignedBinary(
       target='%s%s' % (prefix,
                        omaha_version_info.plugin_signed_file_info.filename),
       source=unsigned_dll,

--- a/omaha/test/build.scons
+++ b/omaha/test/build.scons
@@ -128,7 +128,7 @@ def BuildMSI(version, namespace, exe_name, wxs_template, msi_base_name,
 
   wix_env.Depends(unsigned_msi, additional_dependencies)
 
-  signed_output = env.DualSignedBinary(
+  signed_output = env.SignedBinary(
       target=msi_base_name + '.msi',
       source=unsigned_msi,
   )
@@ -177,7 +177,7 @@ for (major, minor, build, patch) in [(1,0,101,0), (1,0,102,0)]:
       COMPONENT_TEST_RUNNABLE=False
   )
 
-  signed_output = ver_env.DualSignedBinary(
+  signed_output = ver_env.SignedBinary(
       target=signed_target_name,
       source=unsigned_exe,
   )

--- a/omaha/testing/build.scons
+++ b/omaha/testing/build.scons
@@ -675,7 +675,7 @@ if env.Bit('all'):
       COMPONENT_TEST_RUNNABLE=False
   )
 
-  signed_output = save_args_env.DualSignedBinary(
+  signed_output = save_args_env.SignedBinary(
       target='SaveArguments.exe',
       source=unsigned_output,
   )


### PR DESCRIPTION
Binary files must be signed using only one certificate.
